### PR TITLE
Improve rope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,14 +76,18 @@ before_script:
     # must set these flags after installation to avoid running coverage on
     # other dependencies like libcheck
   - if [ "$BUILD_TYPE" = coverage ]; then
-      export CFLAGS="$CFLAGS --coverage" LDFLAGS="$LDFLAGS --coverage";
+      export CFLAGS="$CFLAGS --coverage"
+             CPPFLAGS="$CPPFLAGS -DCOVERAGE"
+             LDFLAGS="$LDFLAGS --coverage";
     fi
 
 after_success:
   - if [ "$BUILD_TYPE" = coverage ]; then
       lcov -c -o coverage.info -d src &&
       lcov -r coverage.info -o coverage.info
+        include/foxbot/error.h
         src/config_lexer.c
+        src/error.c
         src/config_lexer.l
         src/config_parser.c
         &&

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ noinst_LIBRARIES = libfoxbot.a libfoxbotaux.a
 libfoxbot_a_SOURCES = cap.c \
 				 channel.c \
                  conf.c \
+                 error.c \
                  foxbot.c \
                  irc_literal.c \
                  irc_numeric.c \

--- a/src/error.c
+++ b/src/error.c
@@ -1,8 +1,8 @@
 /*
- *   check_foxbot.c -- May 1 2016 9:31:02 EDT
+ *   error.c -- May 8 2016 03:56:56 EDT
  *
  *   This file is part of the foxbot IRC bot
- *   Copyright (C) 2016 Matt Ullman (staticfox at staticfox dot net)
+ *   Copyright (C) 2016 Fylwind Ruzkelt (fyl@wolfpa.ws)
  *
  *   This program is FREE software. You can redistribute it and/or
  *   modify it under the terms of the GNU General Public License
@@ -20,37 +20,36 @@
  *
  */
 
-#include <errno.h>
+#include <config.h>
+
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 
-#include "check_foxbot.h"
-#include "check_server.h"
+#include "error.h"
 
-static void
-add_testcases(Suite *s)
+void
+panic_message(const char *file,
+              uintmax_t line,
+              const char *func,
+              const char *format,
+              ...)
 {
-    connect_parse_setup(s);
-    channel_parse_setup(s);
-    memory_setup(s);
-    rope_setup(s);
-    user_parse_setup(s);
-    cap_parse_setup(s);
+    va_list vlist;
+    va_start(vlist, format);
+    vpanic_message(file, line, func, format, vlist);
+    va_end(vlist);
 }
 
-int
-main()
+void
+vpanic_message(const char *file,
+              uintmax_t line,
+              const char *func,
+              const char *format,
+               va_list vlist)
 {
-    Suite *s = suite_create("check_foxbot");
-
-    add_testcases(s);
-
-    SRunner *runner = srunner_create(s);
-    srunner_set_tap(runner, "-");
-    srunner_run_all(runner, CK_NORMAL);
-
-    int number_failed = srunner_ntests_failed(runner);
-    srunner_free(runner);
-
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    char msg[1024];
+    vsnprintf(msg, sizeof(msg), format, vlist);
+    fprintf(stderr, PACKAGE_NAME ":%s:%lu:%s: %s\n", file, line, func, msg);
+    fflush(stderr);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,76 @@
+/*
+ *   error.h -- May 8 2016 03:49:44 EDT
+ *
+ *   This file is part of the foxbot IRC bot
+ *   Copyright (C) 2016 Fylwind Ruzkelt (fyl@wolfpa.ws)
+ *
+ *   This program is FREE software. You can redistribute it and/or
+ *   modify it under the terms of the GNU General Public License
+ *   as published by the Free Software Foundation; either version 2
+ *   of the License, or (at your option) any later version.
+ *
+ *   This program is distributed in the HOPE that it will be USEFUL,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *   See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, write to the Free Software Foundation,
+ *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef FOX_ERROR_H_
+#define FOX_ERROR_H_
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define panic(...) panic_(__FILE__, __LINE__, __func__, "" __VA_ARGS__);
+
+#define xensure0(expr)                                  \
+    xensure0_((expr), __FILE__, __LINE__, __func__,     \
+              "returned %i instead of zero: " #expr);   \
+
+void panic_message(const char *file,
+                   uintmax_t line,
+                   const char *func,
+                   const char *format,
+                   ...);
+
+void vpanic_message(const char *file,
+                    uintmax_t line,
+                    const char *func,
+                    const char *format,
+                    va_list vlist);
+
+static inline void
+panic_(const char *file,
+       uintmax_t line,
+       const char *func,
+       const char *format,
+       ...)
+{
+    va_list vlist;
+    va_start(vlist, format);
+    vpanic_message(file, line, func, format, vlist);
+    va_end(vlist);
+    abort();
+}
+
+static inline int
+xensure0_(int value,
+          const char *file,
+          uintmax_t line,
+          const char *func,
+          const char *format)
+{
+    if (value) {
+        panic_message(file, line, func, format, value);
+        abort();
+    }
+    return value;
+}
+
+#endif

--- a/src/error.h
+++ b/src/error.h
@@ -73,4 +73,9 @@ xensure0_(int value,
     return value;
 }
 
+#ifdef COVERAGE
+#undef panic
+#define panic(...) (void)0
+#endif
+
 #endif

--- a/src/rope.c
+++ b/src/rope.c
@@ -23,18 +23,22 @@
 #include <config.h>
 
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <foxbot/memory.h>
 #include <foxbot/rope.h>
 
+#include "error.h"
+
 struct rope_segment *
-alloc_rope_segment(const char *data, size_t len)
+xalloc_rope_segment(const void *data, size_t len)
 {
-    static const struct rope_segment ROPE_SEGMENT_EMPTY;
+    if (len > (size_t)(-1) - sizeof(struct rope_segment))
+        panic("segment length too large");
     struct rope_segment *const s = xmalloc(sizeof(*s) + len);
-    *s = ROPE_SEGMENT_EMPTY;
+    s->next = NULL;
     s->len = len;
     memcpy(s->data, data, len);
     return s;
@@ -43,14 +47,23 @@ alloc_rope_segment(const char *data, size_t len)
 void
 append_rope(rope *r, struct rope_segment *s)
 {
+    if (rope_len(r) > (size_t)(-1) - s->len)
+        panic("rope length too large");
+    if (rope_count(r) == (size_t)(-1))
+        panic("rope has too many segments");
+    /* invariant: either both are NULL or both are non-NULL */
+    assert(!!r->_tail == !!r->_head);
     s->next = NULL;
     if (r->_tail) {
+        /* invariant: tail must not be followed by anything */
         assert(!r->_tail->next);
         r->_tail->next = s;
     } else {
         r->_head = s;
     }
     r->_tail = s;
+    r->_len += s->len;
+    ++r->_count;
 }
 
 struct rope_segment *
@@ -60,10 +73,14 @@ shift_rope(rope *r)
     if (s) {
         r->_head = s->next;
         if (!s->next) {
+            /* invariant: head and tail must point to same segment if rope has
+             * only one element */
             assert(r->_tail == s);
             r->_tail = NULL;
         }
         s->next = NULL;
+        r->_len -= s->len;
+        --r->_count;
     }
     return s;
 }
@@ -80,39 +97,43 @@ clear_rope(rope *r)
 void
 append_tsrope(tsrope *r, struct rope_segment *s)
 {
-    pthread_mutex_lock(&r->_mutex);
+    assert(r->_is_initialized == 1);
+    xensure0(pthread_mutex_lock(&r->_mutex));
     append_rope(&r->_rope, s);
     /* I think pthread_cond_signal should be safe here, but I'm using
        broadcast just to be sure */
-    pthread_cond_broadcast(&r->_cond);
-    pthread_mutex_unlock(&r->_mutex);
+    xensure0(pthread_cond_broadcast(&r->_cond));
+    xensure0(pthread_mutex_unlock(&r->_mutex));
 }
 
 struct rope_segment *
 shift_tsrope(tsrope *r)
 {
-    pthread_mutex_lock(&r->_mutex);
+    assert(r->_is_initialized == 1);
+    xensure0(pthread_mutex_lock(&r->_mutex));
     struct rope_segment *const s = shift_rope(&r->_rope);
-    pthread_mutex_unlock(&r->_mutex);
+    xensure0(pthread_mutex_unlock(&r->_mutex));
     return s;
 }
 
 struct rope_segment *
 waitshift_tsrope(tsrope *r)
 {
-    pthread_mutex_lock(&r->_mutex);
+    assert(r->_is_initialized == 1);
+    xensure0(pthread_mutex_lock(&r->_mutex));
     struct rope_segment *s;
     while (!(s = shift_rope(&r->_rope))) {
-        pthread_cond_wait(&r->_cond, &r->_mutex);
+        xensure0(pthread_cond_wait(&r->_cond, &r->_mutex));
     }
-    pthread_mutex_unlock(&r->_mutex);
+    xensure0(pthread_mutex_unlock(&r->_mutex));
     return s;
 }
 
 void
 clear_tsrope(tsrope *r)
 {
-    pthread_mutex_lock(&r->_mutex);
+    assert(r->_is_initialized == 1);
+    xensure0(pthread_mutex_lock(&r->_mutex));
     clear_rope(&r->_rope);
-    pthread_mutex_unlock(&r->_mutex);
+    xensure0(pthread_mutex_unlock(&r->_mutex));
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,4 +18,5 @@ check_foxbot_SOURCES = check_foxbot.c \
                        units/channel_parse.c \
                        units/connect_parse.c \
                        units/memory_parse.c \
+                       units/rope.c \
                        units/user_parse.c

--- a/tests/check_foxbot.h
+++ b/tests/check_foxbot.h
@@ -35,4 +35,5 @@ void connect_parse_setup(Suite *s);
 void channel_parse_setup(Suite *s);
 void user_parse_setup(Suite *s);
 void memory_setup(Suite *s);
+void rope_setup(Suite *s);
 void cap_parse_setup(Suite *s);

--- a/tests/units/rope.c
+++ b/tests/units/rope.c
@@ -1,0 +1,113 @@
+/*
+ *   rope.c -- May 8 2016 04:49:12 EDT
+ *
+ *   This file is part of the foxbot IRC bot
+ *   Copyright (C) 2016 Matt Ullman (staticfox at staticfox dot net)
+ *
+ *   This program is FREE software. You can redistribute it and/or
+ *   modify it under the terms of the GNU General Public License
+ *   as published by the Free Software Foundation; either version 2
+ *   of the License, or (at your option) any later version.
+ *
+ *   This program is distributed in the HOPE that it will be USEFUL,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *   See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, write to the Free Software Foundation,
+ *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <check.h>
+
+#include <foxbot/memory.h>
+#include <foxbot/rope.h>
+
+START_TEST(rope_check)
+{
+    rope r = ROPE_EMPTY;
+    ck_assert_ptr_eq(shift_rope(&r), NULL);
+    append_rope(&r, xalloc_rope_segment(":3", 3));
+    append_rope(&r, xalloc_rope_segment("^.^", 4));
+    ck_assert_uint_eq(rope_len(&r), 7);
+    ck_assert_uint_eq(rope_count(&r), 2);
+    {
+        struct rope_segment *s = shift_rope(&r);
+        ck_assert_str_eq(s->data, ":3");
+        xfree(s);
+    }
+    {
+        struct rope_segment *s = shift_rope(&r);
+        ck_assert_str_eq(s->data, "^.^");
+        xfree(s);
+    }
+}
+END_TEST
+
+static const size_t num_iter = 10000;
+
+static void *
+writer(void *p_r)
+{
+    tsrope *const r = p_r;
+    for (unsigned i = 0; i < num_iter; ++i) {
+        const unsigned data[4] = {i, ~i, i + 1, i - 1};
+        append_tsrope(r, xalloc_rope_segment(data, sizeof(data)));
+    }
+    return NULL;
+}
+
+static void *
+reader(void *p_r)
+{
+    tsrope *const r = p_r;
+    for (unsigned i = 0; i < num_iter; ++i) {
+        const unsigned expected_data[4] = {i, ~i, i + 1, i - 1};
+        struct rope_segment *const s = waitshift_tsrope(r);
+        ck_assert_uint_eq(s->len, sizeof(expected_data));
+        unsigned data[sizeof(expected_data) / sizeof(*expected_data)];
+        memcpy(data, s->data, sizeof(data));
+        for (unsigned j = 0; j < sizeof(data) / sizeof(*data); ++j)
+            ck_assert_uint_eq(expected_data[j], data[j]);
+        xfree(s);
+    }
+    return NULL;
+}
+
+START_TEST(tsrope_check)
+{
+    tsrope r = TSROPE_EMPTY;
+    pthread_t twriter, treader;
+    ck_assert_ptr_eq(shift_tsrope(&r), NULL);
+    append_tsrope(&r, xalloc_rope_segment(":3", 3));
+    append_tsrope(&r, xalloc_rope_segment("^.^", 4));
+    {
+        struct rope_segment *s = shift_tsrope(&r);
+        ck_assert_str_eq(s->data, ":3");
+        xfree(s);
+    }
+    {
+        struct rope_segment *s = shift_tsrope(&r);
+        ck_assert_str_eq(s->data, "^.^");
+        xfree(s);
+    }
+    ck_assert_int_eq(pthread_create(&twriter, NULL, writer, &r), 0);
+    ck_assert_int_eq(pthread_create(&treader, NULL, reader, &r), 0);
+    ck_assert_int_eq(pthread_join(twriter, NULL), 0);
+    ck_assert_int_eq(pthread_join(treader, NULL), 0);
+}
+END_TEST
+
+void
+rope_setup(Suite *s)
+{
+    TCase *tc = tcase_create("rope");
+    tcase_add_test(tc, rope_check);
+    tcase_add_test(tc, tsrope_check);
+    suite_add_tcase(s, tc);
+}


### PR DESCRIPTION
- Rename `alloc_rope_segment` to `xalloc_rope_segment`.
- Fix rope so that its length is actually being tracked.
- Add a counter for number of segments.
- Add asserts to make sure tsrope is initialized properly, since on some platforms the effect of failing to initialize is unnoticeable while on others it will cause subtle bugs. (Related to #23?)
- Add tests for rope and tsrope (including a simple race test).
- Add a module for displaying error messages in exceptional situations.