### PR TITLE
Plugin dir changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,5 +111,4 @@ script:
   - CFLAGS="$CFLAGS -Werror" ./configure --prefix="$HOME/travis_build"
   - make clean
   - make
-  - make install
   - make check

--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_ARG_WITH(plugindir,
   [plugindir=`echo $withval | sed 's/\/$//'`
   AC_MSG_RESULT(yes)],
   [
-    plugindir='${prefix}/plugins'
+    plugindir=${libdir}/${PACKAGE}/plugins
     AC_MSG_RESULT(no)
   ])
 AC_DEFINE_DIR(PLUGIN_DIR, plugindir, [Prefix where plugins are installed.])

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,6 @@ AC_ARG_WITH(plugindir,
     [plugindir='${prefix}/plugins'])
     AC_MSG_RESULT(no)
   ])
-AC_DEFINE_DIR(PLUIGIN_DIR, plugindir, [Prefix where plugins are installed.])
+AC_DEFINE_DIR(PLUGIN_DIR, plugindir, [Prefix where plugins are installed.])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -114,9 +114,8 @@ AC_ARG_WITH(plugindir,
   [AC_HELP_STRING([--with-plugindir=DIR], [Directory to install plugins.])],
   [plugindir=`echo $withval | sed 's/\/$//'`
   AC_MSG_RESULT(yes)],
-  [AS_IF([test "x$enable_fhs_paths" = "xyes"],
-    [plugindir='${pkglibdir}/plugins'],
-    [plugindir='${prefix}/plugins'])
+  [
+    plugindir='${prefix}/plugins'
     AC_MSG_RESULT(no)
   ])
 AC_DEFINE_DIR(PLUGIN_DIR, plugindir, [Prefix where plugins are installed.])

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -6,7 +6,7 @@ AM_LDFLAGS  = -module -export-dynamic -avoid-version -no-undefined -shared
 AM_LDFLAGS += -export-symbols-regex fox_plugin
 LIBS += $(top_srcdir)/src/libfoxbot.la
 
-plugin_libsdir = $(PLUIGIN_DIR)
+plugin_libsdir = $(PLUGIN_DIR)
 
 plugin_libs_LTLIBRARIES = \
                         echo_test.la \

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -216,7 +216,7 @@ iload_plugin(const char *const name, const bool announce)
         return;
     }
 
-    snprintf(buf, sizeof(buf), "%s/%s", PLUIGIN_DIR, name);
+    snprintf(buf, sizeof(buf), "%s/%s", PLUGIN_DIR, name);
 
     void *mod = dlopen(buf, RTLD_NOW);
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -24,6 +24,7 @@
 #include <dlfcn.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <foxbot/conf.h>
@@ -216,7 +217,9 @@ iload_plugin(const char *const name, const bool announce)
         return;
     }
 
-    snprintf(buf, sizeof(buf), "%s/%s", PLUGIN_DIR, name);
+    const char *plugin_dir = getenv("FOXBOT_PLUGIN_DIR");
+    plugin_dir = plugin_dir ? plugin_dir : PLUGIN_DIR;
+    snprintf(buf, sizeof(buf), "%s/%s", plugin_dir, name);
 
     void *mod = dlopen(buf, RTLD_NOW);
 

--- a/tests/check_start.c
+++ b/tests/check_start.c
@@ -29,6 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <time.h>
 
 #include <foxbot/foxbot.h>
@@ -48,6 +49,12 @@ delete_foxbot(void)
 void
 new_foxbot(int port)
 {
+    char path[4096];
+    ck_assert_ptr_ne(getcwd(path, sizeof(path)), NULL);
+    size_t cwdlen = strlen(path);
+    snprintf(path + cwdlen, sizeof(path) - cwdlen, "/../plugins/.libs");
+    ck_assert_int_eq(setenv("FOXBOT_PLUGIN_DIR", path, 1), 0);
+
     char s_port[16];
 
     snprintf(s_port, sizeof(s_port), "%d", port);


### PR DESCRIPTION
- Fix typo (presumably)
- Remove Charybdis thing
- Change default plugin dir to `${prefix}/lib/foxbot/plugins`
- Allow plugin dir to be overriden by an environment variable to simplify testing