### PR TITLE
Avoid casting hook_func

### DIFF
--- a/include/foxbot/hook.h
+++ b/include/foxbot/hook.h
@@ -25,7 +25,7 @@
 
 #include <foxbot/list.h>
 
-typedef void * (*hook_func)(void);
+typedef void (*hook_func)(void);
 
 struct hook_t {
     char *name;

--- a/plugins/echo_test.c
+++ b/plugins/echo_test.c
@@ -68,14 +68,14 @@ say_my_name(void)
 static bool
 register_plugin(void)
 {
-    add_hook("on_privmsg", (hook_func) say_my_name);
+    add_hook("on_privmsg", say_my_name);
     return true;
 }
 
 static bool
 unregister_plugin(void)
 {
-    delete_hook("on_privmsg", (hook_func) say_my_name);
+    delete_hook("on_privmsg", say_my_name);
     return true;
 }
 

--- a/plugins/plugin_manager.c
+++ b/plugins/plugin_manager.c
@@ -195,14 +195,14 @@ done:
 static bool
 register_plugin(void)
 {
-    add_hook("on_privmsg", (hook_func) plugin_manage_command);
+    add_hook("on_privmsg", plugin_manage_command);
     return true;
 }
 
 static bool
 unregister_plugin(void)
 {
-    delete_hook("on_privmsg", (hook_func) plugin_manage_command);
+    delete_hook("on_privmsg", plugin_manage_command);
     return true;
 }
 

--- a/tests/units/hook.c
+++ b/tests/units/hook.c
@@ -39,12 +39,12 @@ START_TEST(hook_check)
 {
     begin_test();
     passer = 0;
-    add_hook("check_hook", (hook_func) check_func);
+    add_hook("check_hook", check_func);
     /* echo_test + check_hook */
     ck_assert_int_eq(hook_count(), 2);
     exec_hook("check_hook");
     ck_assert_int_eq(passer, 1);
-    delete_hook("check_hook", (hook_func) check_func);
+    delete_hook("check_hook", check_func);
     ck_assert_int_eq(hook_count(), 1);
     ck_assert_int_eq(passer, 1);
     end_test();
@@ -55,12 +55,12 @@ START_TEST(hook_privmsg)
 {
     begin_test();
     passer = 0;
-    add_hook("on_privmsg", (hook_func) check_func);
+    add_hook("on_privmsg", check_func);
     ck_assert_ptr_ne(find_channel("#unit_test"), NULL);
     write_and_wait(":test_user1!~test@255.255.255.255 JOIN #unit_test");
     write_and_wait(":test_user1!~test@255.255.255.255 PRIVMSG #unit_test :hi");
     ck_assert_int_eq(passer, 1);
-    delete_hook("on_privmsg", (hook_func) check_func);
+    delete_hook("on_privmsg", check_func);
     end_test();
 }
 END_TEST


### PR DESCRIPTION
The return value isn't being used anyway...

Casting a function pointer to a function pointer of another type and then calling it with the wrong type is undefined behavior.